### PR TITLE
dbus: Fix ptest

### DIFF
--- a/recipes-debian/dbus/dbus-test/run-ptest
+++ b/recipes-debian/dbus/dbus-test/run-ptest
@@ -1,0 +1,31 @@
+#!/bin/sh
+
+output() {
+  retcode=$?
+  if [ $retcode -eq 0 ]
+    then echo "PASS: $i"
+  elif [ $retcode -eq 77 ]
+    then echo "SKIP: $i"
+  else echo "FAIL: $i"
+  fi
+}
+
+export DBUS_TEST_HOMEDIR=./test
+export XDG_RUNTIME_DIR=./test
+export LD_LIBRARY_PATH=@PTEST_PATH@/test/.libs
+
+files=`ls test/test-*`
+
+for i in $files
+do
+     #these programs are used by testcase test-bus, don't run here
+     if [ $i = "test/test-service" ] \
+        || [ $i = "test/test-shell-service" ] \
+        || [ $i = "test/test-segfault" ]
+     then
+         continue
+     fi
+
+     ./$i ./test/data >/dev/null 2>&1
+     output
+done

--- a/recipes-debian/dbus/dbus-test_debian.bb
+++ b/recipes-debian/dbus/dbus-test_debian.bb
@@ -31,13 +31,14 @@ EXTRA_OECONF = "--enable-tests \
                 --enable-installed-tests \
                 --enable-checks \
                 --enable-asserts \
-                --enable-verbose-mode \
                 --enable-largefile \
                 --disable-xml-docs \
                 --disable-doxygen-docs \
                 --disable-libaudit \
                 --with-dbus-test-dir=${PTEST_PATH} \
-                ${EXTRA_OECONF_X}"
+                ${EXTRA_OECONF_X} \
+                --enable-embedded-tests \
+             "
 
 EXTRA_OECONF_append_class-target = " SYSTEMCTL=${base_bindir}/systemctl"
 
@@ -48,6 +49,7 @@ PACKAGECONFIG_class-nativesdk = ""
 PACKAGECONFIG[systemd] = "--enable-systemd --with-systemdsystemunitdir=${systemd_system_unitdir},--disable-systemd --without-systemdsystemunitdir,systemd"
 PACKAGECONFIG[x11] = "--with-x --enable-x11-autolaunch,--without-x --disable-x11-autolaunch, virtual/libx11 libsm"
 PACKAGECONFIG[user-session] = "--enable-user-session --with-systemduserunitdir=${systemd_user_unitdir},--disable-user-session"
+PACKAGECONFIG[verbose-mode] = "--enable-verbose-mode,,,"
 
 do_install() {
     :
@@ -56,11 +58,16 @@ do_install() {
 do_install_ptest() {
 	install -d ${D}${PTEST_PATH}/test
 	l="shell printf refs syslog marshal syntax corrupt dbus-daemon dbus-daemon-eavesdrop loopback relay \
-	   variant uid-permissions syntax spawn sd-activation names monitor message fdpass "
+	   variant uid-permissions syntax spawn sd-activation names monitor message fdpass service shell-service"
 	for i in $l; do install ${B}/test/.libs/test-$i ${D}${PTEST_PATH}/test; done
 
 	l="bus bus-system bus-launch-helper"
 	for i in $l; do install ${B}/bus/.libs/test-$i ${D}${PTEST_PATH}/test; done
+
+	install -d ${D}${PTEST_PATH}/bus
+	install ${B}/bus/.libs/dbus-daemon-launch-helper-test ${D}${PTEST_PATH}/bus
+
+	install ${B}/test/test-segfault ${D}${PTEST_PATH}/test
 
 	cp -r ${B}/test/data ${D}${PTEST_PATH}/test
 	install ${B}/dbus/.libs/test-dbus ${D}${PTEST_PATH}/test

--- a/recipes-debian/dbus/dbus_debian.bb
+++ b/recipes-debian/dbus/dbus_debian.bb
@@ -20,7 +20,13 @@ DEPENDS = "expat virtual/libintl autoconf-archive"
 RDEPENDS_dbus_class-native = ""
 RDEPENDS_dbus_class-nativesdk = ""
 
+# The following lines are obtained from ptest.bbclass
+PTEST_ENABLED = "${@bb.utils.contains('DISTRO_FEATURES', 'ptest', '1', '0', d)}"
+PTEST_ENABLED_class-native = ""
+PTEST_ENABLED_class-nativesdk = ""
+PTEST_ENABLED_class-cross-canadian = ""
 PACKAGES += "${@bb.utils.contains('PTEST_ENABLED', '1', 'dbus-ptest', '', d)}"
+
 ALLOW_EMPTY_dbus-ptest = "1"
 RDEPENDS_dbus-ptest_class-target = "dbus-test-ptest"
 


### PR DESCRIPTION
# Purpose of pull request

This PR fixes ptest of dbus package.
After applying this change, ptest of dbus will be installed if ptest is enabled.

Currently ptest of dbus will not be installed even if ptest is enabled.

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " dbus"
EOS
$ bitbake core-image-minimal
...(snip)...
$ runqemu nographic slirp qemuparams="-m 4096"
...(snip)...
$ ptest-runner -l | grep dbus

### "dbus-test" should be shown here, but actually not. ###
```

This is because dbus recipe doesn't respect "ptest" in `DISTRO_FEATURES` variable unlike ptest.bbclass.
Therefore, this PR will fix dbus recipe to make sure it is respected.

# Note

If we build dbus with test (`--enable-tests` in configure), it requires glib-2.0 additionally.
glib-2.0 requires dbus, so it causes circular build-dependency between dbus and glib-2.0.

To avoid this circular build-dependency, test code of dbus is split out as "dbus-test" recipe in current implementation.
As a result, 

* glib-2.0 depends on dbus
* dbus-test depends on glib-2.0.

This workaround makes dbus-test build-able, but the drawback is that it is recognized as "dbus-test" not "dbus" from ptest-runner. I think this is limitation of current implementation.

```
root@qemuarm64:~# ptest-runner -l
Available ptests:
acl     /usr/lib/acl/ptest/run-ptest
busybox /usr/lib/busybox/ptest/run-ptest
dbus-test       /usr/lib/dbus-test/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
```

# Test
## How to test

1. Enable ptest and install dbus package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " dbus"
EOS
```

2. Build core-image-minimal

```
$ bitbake core-image-minimal
```

3.  Run qemu and run ptest of dbus

```
$ runqemu nographic slirp qemuparams="-m 4096"
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 dbus-test
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
dbus-test       /usr/lib/dbus-test/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 dbus-test
START: ptest-runner
2024-04-09T00:40
BEGIN: /usr/lib/dbus-test/ptest
[   33.587143] random: test-bus: uninitialized urandom read (12 bytes read)
[   33.593804] random: test-bus: uninitialized urandom read (12 bytes read)
[   33.595391] random: test-bus: uninitialized urandom read (10 bytes read)
dbus-daemon[2037]: dbus-daemon transaction failed (OOM), sending error to sender uid=0 pid=2037 comm="./test/test-bus ./test/data "
dbus-daemon[2037]: dbus-daemon transaction failed (OOM), sending error to sender uid=0 pid=2037 comm="./test/test-bus ./test/data "
dbus-daemon[2037]: dbus-daemon transaction failed (OOM), sending error to sender uid=0 pid=2037 comm="./test/test-bus ./test/data "
...(snip)...
PASS: test/test-syslog
SKIP: test/test-uid-permissions
PASS: test/test-variant
dbus-daemon[3000]: [session uid=0 pid=3000] Reloaded configuration
DURATION: 1094
END: /usr/lib/dbus-test/ptest
2024-04-09T00:58
STOP: ptest-runner
```

[ptest-dbus.log](https://github.com/ml-ichiro/meta-debian/files/14912501/ptest-dbus.log)

## Test summary

* TOTAL: 23
  * PASS: 18
  * FAIL: 3
  * SKIP: 2

I run this ptest 3 times and obtained the same results.