### PR TITLE
libnftnl: Add ptest

### DIFF
--- a/recipes-debian/libnftnl/libnftnl/0003-configure.ac-Add-serial-tests.patch
+++ b/recipes-debian/libnftnl/libnftnl/0003-configure.ac-Add-serial-tests.patch
@@ -1,0 +1,30 @@
+From 9c0b53d2e3fd511302eb86fc1ce71513d5ea357a Mon Sep 17 00:00:00 2001
+From: Trevor Gamblin <trevor.gamblin@windriver.com>
+Date: Tue, 14 Dec 2021 12:31:12 -0500
+Subject: [PATCH] configure.ac: Add serial-tests
+
+ptest needs buildtest-TESTS and runtest-TESTS targets.
+serial-tests is required to generate those targets.
+
+Upstream-Status: Inappropriate (default automake behavior incompatible with ptest)
+
+Signed-off-by: Trevor Gamblin <trevor.gamblin@windriver.com>
+---
+ configure.ac | 4 +++-
+ 1 file changed, 3 insertions(+), 1 deletion(-)
+
+diff --git a/configure.ac b/configure.ac
+index ba4fc96..d7468d0 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -8,7 +8,9 @@ AC_CONFIG_HEADERS([config.h])
+ m4_ifdef([AM_PROG_AR], [AM_PROG_AR])
+ 
+ AM_INIT_AUTOMAKE([-Wall foreign tar-pax no-dist-gzip dist-bzip2
+-	1.6 subdir-objects])
++	1.6 subdir-objects serial-tests])
++
++AM_EXTRA_RECURSIVE_TARGETS([buildtest-TESTS])
+ 
+ dnl kernel style compile messages
+ m4_ifdef([AM_SILENT_RULES], [AM_SILENT_RULES([yes])])

--- a/recipes-debian/libnftnl/libnftnl/run-ptest
+++ b/recipes-debian/libnftnl/libnftnl/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -C tests -k runtest-TESTS

--- a/recipes-debian/libnftnl/libnftnl_debian.bb
+++ b/recipes-debian/libnftnl/libnftnl_debian.bb
@@ -13,7 +13,35 @@ require recipes-debian/sources/libnftnl.inc
 DEBIAN_QUILT_PATCHES = ""
 
 SRC_URI += "file://0001-Move-exports-before-symbol-definition.patch \
-	    file://0002-avoid-naming-local-function-as-one-of-printf-family.patch \
-	   "
+            file://0002-avoid-naming-local-function-as-one-of-printf-family.patch \
+            file://0003-configure.ac-Add-serial-tests.patch \
+            file://run-ptest \
+           "
 
-inherit autotools pkgconfig
+inherit autotools pkgconfig ptest
+
+DEPENDS = "libmnl"
+RDEPENDS_${PN}-ptest += "bash python3-core make"
+
+TESTDIR = "tests"
+
+do_compile_ptest() {
+    cp -rf ${S}/build-aux .
+    oe_runmake buildtest-TESTS
+}
+
+do_install_ptest() {
+    cp -rf ${B}/build-aux ${D}${PTEST_PATH}
+    install -d ${D}${PTEST_PATH}/${TESTDIR}
+    cp -rf ${B}/${TESTDIR}/Makefile ${D}${PTEST_PATH}/${TESTDIR}
+
+    # the binaries compiled in ${TESTDIR} will look for a compiler to
+    # use, which will cause failures. Substitute the binaries in
+    # ${TESTDIR}/.libs instead
+    cp -rf ${B}/${TESTDIR}/.libs/* ${D}${PTEST_PATH}/${TESTDIR}
+
+    # Alter the Makefile so that it does not try and rebuild anything in
+    # other nonexistent paths before running the actual tests
+    sed -i 's/^Makefile/_Makefile/'  ${D}${PTEST_PATH}/${TESTDIR}/Makefile
+}
+


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of libnftnl package based on the following recipe:

* base recipe: [meta-networking/recipes-filter/libnftnl/libnftnl_1.2.6.bb](https://git.openembedded.org/meta-openembedded/tree/meta-networking/recipes-filter/libnftnl/libnftnl_1.2.6.bb?id=3991d85383b466a4948283cfd0167213a1dd2311)
* base branch: master
* base commit: 3991d85383b466a4948283cfd0167213a1dd2311

# Note

`0003-configure.ac-Add-serial-tests.patch` is necessary to build test code, and almost identical to [`0001-configure.ac-Add-serial-tests.patch`](https://git.openembedded.org/meta-openembedded/tree/meta-networking/recipes-filter/libnftnl/libnftnl/0001-configure.ac-Add-serial-tests.patch?id=3991d85383b466a4948283cfd0167213a1dd2311) of meta-networking except surrounding lines.

# Test
## How to test

1. Enable ptest and install libnftnl package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " libnftnl"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of libnftnl

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 libnftnl
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
libnftnl        /usr/lib/libnftnl/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 libnftnl
START: ptest-runner
2024-04-09T04:28
BEGIN: /usr/lib/libnftnl/ptest
make: Entering directory '/usr/lib/libnftnl/ptest/tests'
./nft-table-test: OK
PASS: nft-table-test
./nft-chain-test: OK
PASS: nft-chain-test
./nft-object-test: OK
PASS: nft-object-test
./nft-rule-test: OK
PASS: nft-rule-test
./nft-set-test: OK
PASS: nft-set-test
./nft-flowtable-test: OK
PASS: nft-flowtable-test
./nft-expr_bitwise-test: OK
PASS: nft-expr_bitwise-test
./nft-expr_byteorder-test: OK
PASS: nft-expr_byteorder-test
./nft-expr_counter-test: OK
PASS: nft-expr_counter-test
./nft-expr_cmp-test: OK
PASS: nft-expr_cmp-test
./nft-expr_ct-test: OK
PASS: nft-expr_ct-test
./nft-expr_dup-test: OK
PASS: nft-expr_dup-test
./nft-expr_fwd-test: OK
PASS: nft-expr_fwd-test
./nft-expr_exthdr-test: OK
PASS: nft-expr_exthdr-test
./nft-expr_immediate-test: OK
PASS: nft-expr_immediate-test
./nft-expr_limit-test: OK
PASS: nft-expr_limit-test
./nft-expr_lookup-test: OK
PASS: nft-expr_lookup-test
./nft-expr_log-test: OK
PASS: nft-expr_log-test
./nft-expr_match-test: OK
PASS: nft-expr_match-test
./nft-expr_masq-test: OK
PASS: nft-expr_masq-test
./nft-expr_meta-test: OK
PASS: nft-expr_meta-test
./nft-expr_numgen-test: OK
PASS: nft-expr_numgen-test
./nft-expr_nat-test: OK
PASS: nft-expr_nat-test
./nft-expr_objref-test: OK
PASS: nft-expr_objref-test
./nft-expr_payload-test: OK
PASS: nft-expr_payload-test
./nft-expr_queue-test: OK
PASS: nft-expr_queue-test
./nft-expr_range-test: OK
PASS: nft-expr_range-test
./nft-expr_quota-test: OK
PASS: nft-expr_quota-test
./nft-expr_redir-test: OK
PASS: nft-expr_redir-test
./nft-expr_reject-test: OK
PASS: nft-expr_reject-test
./nft-expr_target-test: OK
PASS: nft-expr_target-test
./nft-expr_hash-test: OK
PASS: nft-expr_hash-test
===================
All 32 tests passed
===================
make: Leaving directory '/usr/lib/libnftnl/ptest/tests'
DURATION: 4
END: /usr/lib/libnftnl/ptest
2024-04-09T04:28
STOP: ptest-runner
```

[ptest-libnftnl.log](https://github.com/ml-ichiro/meta-debian/files/14913460/ptest-libnftnl.log)

## Test summary

* TOTAL: 32
  * PASS: 32
  * FAIL: 0

I run this ptest 3 times and obtained the same results.