### PR TITLE
libpng: Add ptest

### DIFF
--- a/recipes-debian/libpng/libpng/run-ptest
+++ b/recipes-debian/libpng/libpng/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -k check-TESTS

--- a/recipes-debian/libpng/libpng_debian.bb
+++ b/recipes-debian/libpng/libpng_debian.bb
@@ -15,7 +15,7 @@ UPSTREAM_CHECK_URI = "http://libpng.org/pub/png/libpng.html"
 
 BINCONFIG = "${bindir}/libpng-config ${bindir}/libpng16-config"
 
-inherit autotools binconfig-disabled pkgconfig
+inherit autotools binconfig-disabled pkgconfig ptest
 
 #DPN = "libpng1.6"
 # override 'S' set by debian-package-ng
@@ -29,5 +29,53 @@ EXTRA_OECONF_append_class-target = " ${@bb.utils.contains("TUNE_FEATURES", "neon
 PACKAGES =+ "${PN}-tools"
 
 FILES_${PN}-tools = "${bindir}/png-fix-itxt ${bindir}/pngfix ${bindir}/pngcp"
+
+SRC_URI += " \
+    file://run-ptest \
+"
+
+do_compile_ptest() {
+    oe_runmake check TESTS=""
+}
+
+do_install_ptest() {
+    install -m 755 ${S}/test-driver ${D}${PTEST_PATH}/
+    install -m 644 ${S}/pngtest.png ${D}${PTEST_PATH}/
+    cp -r ${B}/* ${D}${PTEST_PATH}/
+    cp -r ${S}/tests/ ${D}${PTEST_PATH}/
+    cp -r ${S}/contrib/pngsuite/ ${D}${PTEST_PATH}/contrib/
+    cp -r ${S}/contrib/testpngs/ ${D}${PTEST_PATH}/contrib/
+    for d in . mips powerpc; do
+        cp ${B}/$d/.libs/* ${D}${PTEST_PATH}/
+    done
+
+    # Remove these files to avoid bash dependency
+    rm ${D}${PTEST_PATH}/*-libtool
+    rm ${D}${PTEST_PATH}/config.status
+
+    install -m 644 ${S}/*.h ${D}${PTEST_PATH}/
+    install -m 644 ${S}/*.dfa ${D}${PTEST_PATH}/
+    install -m 644 ${S}/scripts/*.dfa ${D}${PTEST_PATH}/scripts/
+    for d in . contrib/libtests contrib/tools mips powerpc; do
+        install -m 644 ${S}/$d/*.c ${D}${PTEST_PATH}/$d/
+    done
+
+    install -m 644 ${S}/scripts/options.awk ${D}${PTEST_PATH}/scripts/
+    sed -i \
+        -e 's|^#!/bin/awk|#!/usr/bin/awk|g' \
+        ${D}${PTEST_PATH}/scripts/options.awk
+
+    install -m 644 ${B}/Makefile ${D}${PTEST_PATH}/
+    sed -i \
+        -e 's|^VPATH =.*$|VPATH = .|g' \
+        -e 's|^Makefile:.*$|Makefile:|g' \
+        -e 's|^srcdir =.*|srcdir = .|g' \
+        -e 's|^top_srcdir =.*|top_srcdir = .|g' \
+        -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
+        -e 's|^abs_top_srcdir =.*|abs_top_srcdir = .|g' \
+        ${D}${PTEST_PATH}/Makefile
+}
+
+RDEPENDS_${PN}-ptest += "make gawk"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of libpng package.

This ptest executes `make check-TESTS`. Test codes are located at `tests/` directory in the source code of libpng.

# Test
## How to test

1. Enable ptest and install libpng package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " libpng"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of libpng

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 libpng
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
libpng  /usr/lib/libpng/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 libpng
START: ptest-runner
2024-04-09T06:30
BEGIN: /usr/lib/libpng/ptest
make[1]: Entering directory '/usr/lib/libpng/ptest'
PASS: tests/pngtest
PASS: tests/pngtest-badpngs
PASS: tests/pngvalid-gamma-16-to-8
PASS: tests/pngvalid-gamma-alpha-mode
PASS: tests/pngvalid-gamma-background
PASS: tests/pngvalid-gamma-expand16-alpha-mode
PASS: tests/pngvalid-gamma-expand16-background
PASS: tests/pngvalid-gamma-expand16-transform
PASS: tests/pngvalid-gamma-sbit
PASS: tests/pngvalid-gamma-threshold
PASS: tests/pngvalid-gamma-transform
PASS: tests/pngvalid-progressive-size
PASS: tests/pngvalid-progressive-interlace-standard
PASS: tests/pngvalid-transform
PASS: tests/pngvalid-progressive-standard
PASS: tests/pngvalid-standard
PASS: tests/pngstest-1.8
PASS: tests/pngstest-1.8-alpha
PASS: tests/pngstest-linear
PASS: tests/pngstest-linear-alpha
PASS: tests/pngstest-none
PASS: tests/pngstest-none-alpha
PASS: tests/pngstest-sRGB
PASS: tests/pngstest-sRGB-alpha
PASS: tests/pngunknown-IDAT
PASS: tests/pngunknown-discard
PASS: tests/pngunknown-if-safe
PASS: tests/pngunknown-sAPI
PASS: tests/pngunknown-sTER
PASS: tests/pngunknown-save
PASS: tests/pngunknown-vpAg
PASS: tests/pngimage-quick
[ 2023.666173] random: crng init done
[ 2023.666833] random: 3 urandom warning(s) missed due to ratelimiting
PASS: tests/pngimage-full
============================================================================
Testsuite summary for libpng 1.6.36
============================================================================
# TOTAL: 33
# PASS:  33
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/libpng/ptest'
DURATION: 2029
END: /usr/lib/libpng/ptest
2024-04-09T07:03
STOP: ptest-runner
```

[ptest-libpng.log](https://github.com/ml-ichiro/meta-debian/files/14915660/ptest-libpng.log)

## Test summary

* TOTAL: 33
  * PASS: 33
  * FAIL: 0

I run this ptest 3 times and obtained the same results.