### PR TITLE
libxau: Add ptest

### DIFF
--- a/recipes-debian/xorg-lib/libxau/0001-Autest.c-Fix-return-code.patch
+++ b/recipes-debian/xorg-lib/libxau/0001-Autest.c-Fix-return-code.patch
@@ -1,0 +1,21 @@
+From 8a550e5feccb0b2bc621754ee5da61ec16c99b81 Mon Sep 17 00:00:00 2001
+From: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+Date: Wed, 1 May 2024 13:02:53 +0900
+Subject: [PATCH] Autest.c: Fix return code
+
+Signed-off-by: Kazuho Sasaki <sasaki.kazuho@meta.co.jp>
+---
+ Autest.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/Autest.c b/Autest.c
+index efb3da8..2c01f53 100644
+--- a/Autest.c
++++ b/Autest.c
+@@ -70,5 +70,5 @@ main (int argc, char **argv)
+ 	state = XauWriteAuth (output, &test_data);
+ 	fclose (output);
+     }
+-    return (state = 1) ? 0 : 1;
++    return (state == 1) ? 0 : 1;
+ }

--- a/recipes-debian/xorg-lib/libxau/run-ptest
+++ b/recipes-debian/xorg-lib/libxau/run-ptest
@@ -1,0 +1,2 @@
+#!/bin/sh
+make -k check-TESTS

--- a/recipes-debian/xorg-lib/libxau_debian.bb
+++ b/recipes-debian/xorg-lib/libxau_debian.bb
@@ -13,7 +13,12 @@ require recipes-debian/sources/libxau.inc
 DEBIAN_PATCH_TYPE = "nopatch"
 DEBIAN_UNPACK_DIR = "${WORKDIR}/${XORG_PN}-${PV}"
 
-inherit gettext
+inherit gettext ptest
+
+SRC_URI += " \
+    file://run-ptest \
+    file://0001-Autest.c-Fix-return-code.patch \
+"
 
 LICENSE = "MIT-style"
 LIC_FILES_CHKSUM = "file://COPYING;md5=7908e342491198401321cec1956807ec"
@@ -22,5 +27,31 @@ DEPENDS += " xorgproto"
 PROVIDES = "xau"
 
 XORG_PN = "libXau"
+
+do_compile_ptest() {
+    oe_runmake check TESTS=
+}
+
+do_install_ptest() {
+    install -m 644 ${S}/test-driver ${D}${PTEST_PATH}
+    install -m 644 ${S}/*.c ${D}${PTEST_PATH}
+
+    install -m 644 ${B}/Makefile ${D}${PTEST_PATH}
+    sed -i \
+        -e 's|^VPATH =.*$|VPATH = .|g' \
+        -e 's|^Makefile:.*$|Makefile:|g' \
+        -e 's|^srcdir =.*|srcdir = .|g' \
+        -e 's|^top_srcdir =.*|top_srcdir = .|g' \
+        -e 's|^abs_srcdir =.*|abs_srcdir = .|g' \
+        -e 's|^abs_top_srcdir =.*|abs_top_srcdir = .|g' \
+        ${D}${PTEST_PATH}/Makefile
+
+    install -m 644 ${B}/*.lo ${D}${PTEST_PATH}
+    install -m 644 ${B}/*.la ${D}${PTEST_PATH}
+    install -m 644 ${B}/*.o ${D}${PTEST_PATH}
+    install -m 755 ${B}/.libs/* ${D}${PTEST_PATH}
+}
+
+RDEPENDS_${PN}-ptest += "make gawk"
 
 BBCLASSEXTEND = "native nativesdk"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of libxau package.

This ptest executes `make check-TESTS`.

# Note

The test binary (Autest) always returns 0, namely the test unconditionally passes. This is apparently problematic. `0001-Autest.c-Fix-return-code.patch` fixes it.

Autest.c
```c
int
main (int argc, char **argv)
{

...(snip)... 

   if (output) {
	state = XauWriteAuth (output, &test_data);
	fclose (output);
    }
    return (state = 1) ? 0 : 1;
}
```

diff part of `0001-Autest.c-Fix-return-code.patch`
```diff
diff --git a/Autest.c b/Autest.c
index efb3da8..2c01f53 100644
--- a/Autest.c
+++ b/Autest.c
@@ -70,5 +70,5 @@ main (int argc, char **argv)
 	state = XauWriteAuth (output, &test_data);
 	fclose (output);
     }
-    return (state = 1) ? 0 : 1;
+    return (state == 1) ? 0 : 1;
 }
```

# Test
## How to test

1. Enable ptest and install libxau package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " libxau"
EOS
```

2. Build core-image-minimal image

```
$ bitbake core-image-minimal
```

3. Run qemu and execute ptest of libxau

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 libxau
```

Also, I confirmed that SDK builds succeed with the following settings:

* Set `DISTRO=deby` and run `bitbake core-image-minimal -c populate_sdk` with meta-debian and poky
* Set `DISTRO=emlinux` and run `bitbake core-image-minimal-sdk -c populate_sdk` with meta-debian, meta-debian-extended, meta-emlinux and poky

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
libxau  /usr/lib/libxau/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 libxau
START: ptest-runner
2024-05-01T04:14
BEGIN: /usr/lib/libxau/ptest
make[1]: Entering directory '/usr/lib/libxau/ptest'
PASS: Autest
============================================================================
Testsuite summary for libXau 1.0.8
============================================================================
# TOTAL: 1
# PASS:  1
# SKIP:  0
# XFAIL: 0
# FAIL:  0
# XPASS: 0
# ERROR: 0
============================================================================
make[1]: Leaving directory '/usr/lib/libxau/ptest'
DURATION: 2
END: /usr/lib/libxau/ptest
2024-05-01T04:14
STOP: ptest-runner
```

[ptest-libxau.log](https://github.com/ml-ichiro/meta-debian/files/15173763/ptest-libxau.log)

## Test summary

* TOTAL: 1
  * PASS: 1
  * FAIL: 0

I run this ptest 3 times and obtained the same results.