### PR TITLE
iptables: Add ptest

### DIFF
--- a/recipes-debian/iptables/iptables/run-ptest
+++ b/recipes-debian/iptables/iptables/run-ptest
@@ -1,0 +1,17 @@
+#!/bin/sh
+
+IPTABLESLIB=@libdir@/iptables
+cd ${IPTABLESLIB}/ptest || exit 1
+
+LOG="${IPTABLESLIB}/ptest/iptables_ptest_$(date +%Y%m%d-%H%M%S).log"
+iptables/tests/shell/run-tests.sh 2>&1 | sed -E '/I: \[OK\]/ s/^/PASS: / ; /W: \[FAILED\]/ s/^/FAIL: /' | sed "s,\x1B\[[0-9;]*[a-zA-Z],,g" | tee -a "${LOG}"
+
+passed=$(grep -c PASS: "${LOG}")
+failed=$(grep -c FAIL: "${LOG}")
+all=$((passed + failed))
+
+(   echo "=== Test Summary ==="
+    echo "TOTAL: ${all}"
+    echo "PASSED: ${passed}"
+    echo "FAILED: ${failed}"
+) | tee -a "${LOG}"

--- a/recipes-debian/iptables/iptables_debian.bb
+++ b/recipes-debian/iptables/iptables_debian.bb
@@ -36,7 +36,7 @@ PACKAGECONFIG[ipv6] = "--enable-ipv6,--disable-ipv6,"
 PACKAGECONFIG[libnfnetlink] = "--enable-libnfnetlink,--disable-libnfnetlink,libnfnetlink libnetfilter-conntrack"
 
 # libnftnl recipe is in meta-networking layer(previously known as libnftables)
-PACKAGECONFIG[libnftnl] = "--enable-nftables,--disable-nftables,libnftnl"
+PACKAGECONFIG[libnftnl] = "--enable-nftables,--disable-nftables,libnftnl bison-native"
 
 do_configure_prepend() {
 	# Remove some libtool m4 files

--- a/recipes-debian/iptables/iptables_debian.bb
+++ b/recipes-debian/iptables/iptables_debian.bb
@@ -84,3 +84,36 @@ do_install_ptest () {
 }
 
 RDEPENDS_${PN}-ptest = "bash diffutils findutils util-linux"
+RRECOMMENDS_${PN}-ptest = " \
+    kernel-module-iptable-mangle \
+    kernel-module-iptable-raw \
+    kernel-module-iptable-security \
+    kernel-module-ip6-tables \
+    kernel-module-ip6table-raw \
+    kernel-module-ip6table-mangle \
+    kernel-module-ip6table-nat \
+    kernel-module-ip6table-filter \
+    kernel-module-ip6table-security \
+    kernel-module-nfnetlink \
+    kernel-module-nfnetlink-log \
+    kernel-module-xt-nflog \
+    kernel-module-xt-multiport \
+    kernel-module-xt-log \
+    kernel-module-xt-mac \
+    kernel-module-xt-tcpmss \
+    kernel-module-xt-limit \
+    kernel-module-xt-ct \
+    kernel-module-xt-helper \
+    kernel-module-xt-checksum \
+    kernel-module-xt-state \
+    kernel-module-xt-mark \
+    kernel-module-xt-comment \
+    kernel-module-xt-tcpudp \
+    kernel-module-xt-conntrack \
+    kernel-module-nf-log-common \
+    kernel-module-nf-log-ipv4 \
+    kernel-module-nf-conntrack-pptp \
+    kernel-module-nf-conntrack-netbios-ns \
+    kernel-module-ipt-reject \
+    kernel-module-ip6t-reject \
+"

--- a/recipes-debian/iptables/iptables_debian.bb
+++ b/recipes-debian/iptables/iptables_debian.bb
@@ -19,11 +19,12 @@ require recipes-debian/sources/iptables.inc
 FILESPATH_append = ":${COREBASE}/meta/recipes-extended/iptables/iptables"
 
 SRC_URI += " \
+           file://run-ptest \
            file://0001-configure-Add-option-to-enable-disable-libnfnetlink.patch \
            file://0002-configure.ac-only-check-conntrack-when-libnfnetlink-enabled.patch \
 "
 
-inherit autotools pkgconfig
+inherit autotools pkgconfig ptest
 
 EXTRA_OECONF = "--with-kernel=${STAGING_INCDIR}"
 
@@ -70,3 +71,16 @@ RRECOMMENDS_${PN} = " \
     kernel-module-nf-nat \
     kernel-module-ipt-masquerade \
 "
+
+do_install_ptest () {
+    install -d ${D}${PTEST_PATH}/iptables/tests
+
+    install -m755 ${B}/iptables/.libs/* ${D}${PTEST_PATH}/iptables
+    cp -r ${B}/extensions ${D}${PTEST_PATH}
+    cp -r ${S}/iptables/tests/shell ${D}${PTEST_PATH}/iptables/tests
+
+    # handle multilib
+    sed -i s:@libdir@:${libdir}:g ${D}${PTEST_PATH}/run-ptest
+}
+
+RDEPENDS_${PN}-ptest = "bash diffutils findutils util-linux"


### PR DESCRIPTION
# Purpose of pull request

This PR adds ptest of iptables package based on the following test code:

- package: iptables-1.8.2
- test code directory path:  `${S}/iptables/tests`

couldn't find any reference recipes that add ptest.

# Test

## How to test

1. Add kernel configurations for ptest of iptables

Apply the following change to meta-debian

```diff
diff --git a/recipes-kernel/linux/linux-base_git.bb b/recipes-kernel/linux/linux-base_git.bb
index ca0814ac..fe0c6d8e 100644
--- a/recipes-kernel/linux/linux-base_git.bb
+++ b/recipes-kernel/linux/linux-base_git.bb
@@ -116,3 +116,5 @@ KERNEL_PRIORITY = "1"

 # extra tasks
 addtask kernel_link_images after do_compile before do_strip
+
+SRC_URI += "${@bb.utils.contains("DISTRO_FEATURES", "ptest", "file://ptest.config","", d)}"
```

Also, create the following kernel configurations to `recipes-kernel/linux/files/ptest.config` in meta-debian

<details>
<summary>ptest.config</summary>

```
CONFIG_IP_NF_RAW=m
CONFIG_IP_NF_SECURITY=m
CONFIG_IP6_NF_RAW=m
CONFIG_IP6_NF_SECURITY=m
CONFIG_NETFILTER_XT_MARK=m
CONFIG_NETFILTER_XT_CONNMARK=m
CONFIG_NETFILTER_XT_TARGET_CONNMARK=m
CONFIG_NETFILTER_XT_TARGET_MARK=m
CONFIG_NETFILTER_XT_TARGET_TCPMSS=m
CONFIG_NETFILTER_XT_TARGET_CT=m
CONFIG_NETFILTER_XT_TARGET_NFLOG=m
CONFIG_NETFILTER_XT_MATCH_CONNMARK=m
CONFIG_NETFILTER_XT_MATCH_MARK=m
CONFIG_NETFILTER_XT_MATCH_COMMENT=m
CONFIG_NETFILTER_XT_MATCH_STATE=m
CONFIG_NETFILTER_XT_MATCH_LIMIT=m
CONFIG_NETFILTER_XT_MATCH_HELPER=m
CONFIG_NETFILTER_XT_MATCH_MAC=m
CONFIG_NETFILTER_XT_MATCH_TCPMSS=m
CONFIG_NETFILTER_XT_MATCH_MULTIPORT=m
CONFIG_NF_CONNTRACK_PPTP=m
CONFIG_NF_CONNTRACK_NETBIOS_NS=m
```
</details>

3. Enable ptest and install iptables package

```
$ . ./repos/poky/oe-init-build-env build
$ bitbake-layers add-layer ../repos/meta-debian/
$ cat << EOS >> conf/local.conf
DISTRO = "deby"
MACHINE = "qemuarm64"
PACKAGE_CLASSES = "package_deb"
DISTRO_FEATURES_append = " ptest"
EXTRA_IMAGE_FEATURES += "ptest-pkgs"
IMAGE_INSTALL_append = " iptables"
EOS
```

4. Build core-image-minimal

```
$ bitbake core-image-minimal
```

5. Run qemu and execute ptest of iptables

```
$ runqemu nographic slirp
...(snip)...
# ptest-runner -l
...(snip)...
# ptest-runner -t 3600 iptables
```

Also, I confirmed that SDK build succeeds with `bitbake core-image-minimal -c populate_sdk`.

## Test result

```
# ptest-runner -l
Available ptests:
busybox /usr/lib/busybox/ptest/run-ptest
iptables        /usr/lib/iptables/ptest/run-ptest
util-linux      /usr/lib/util-linux/ptest/run-ptest
zlib    /usr/lib/zlib/ptest/run-ptest
# ptest-runner -t 3600 iptables
START: ptest-runner
2024-05-10T02:25
BEGIN: /usr/lib/iptables/ptest
[  201.561051] random: udevd: uninitialized urandom read (16 bytes read)
[  201.571141] random: udevd: uninitialized urandom read (16 bytes read)
[  201.571493] random: udevd: uninitialized urandom read (16 bytes read)
[  201.595363] udevd[1436]: specified group 'kvm' unknown
[  202.054198] NET: Registered protocol family 10
[  202.081796] Segment Routing with IPv6
[  204.906220] random: mktemp: uninitialized urandom read (10 bytes read)
[  207.634183] random: mktemp: uninitialized urandom read (10 bytes read)
[  211.997636] random: mktemp: uninitialized urandom read (10 bytes read)

I: [EXECUTING]   ./iptables/tests/shell/testcases/arptables/0001-arptables-save-restore_0
PASS: I: [OK]          ./iptables/tests/shell/testcases/arptables/0001-arptables-save-restore_0
I: [EXECUTING]   ./iptables/tests/shell/testcases/arptables/0002-arptables-restore-defaults_0
PASS: I: [OK]          ./iptables/tests/shell/testcases/arptables/0002-arptables-restore-defaults_0
I: [EXECUTING]   ./iptables/tests/shell/testcases/chain/0001duplicate_1
PASS: I: [OK]          ./iptables/tests/shell/testcases/chain/0001duplicate_1
...(snip)...
I: nft results: [OK] 1 [FAILED] 24 [TOTAL] 25
I: combined results: [OK] 26 [FAILED] 24 [TOTAL] 50
=== Test Summary ===
TOTAL: 50
PASSED: 26
FAILED: 24
DURATION: 31
END: /usr/lib/iptables/ptest
2024-05-10T02:25
STOP: ptest-runner
```

[ptest-iptables.log](https://github.com/ml-ichiro/meta-debian/files/15269758/ptest-iptables.log)

## Test summary

* TOTAL: 50
  * PASS: 26
  * FAIL: 24

I run this ptest 3 times and obtained the same results.

# Excuse of failures

Most of nft tests failed as follows:

```
I: nft results: [OK] 1 [FAILED] 24 [TOTAL] 25
```

This is because `xtables-nft-multi` (iptables command using nftables kernel API) is not built by default.

`xtables-nft-multi` is built if `PACKAGECONFIG` has `libnftnl`.
However actually build fails in do_configure as follows if it is enabled, so also fix it in this PR.

```
| checking for bison... no
| checking for byacc... no
| *** Error: No suitable bison/yacc found. ***
|     Please install the 'bison' package.
```

All of other tests passed as follows:

```
I: legacy results: [OK] 25 [FAILED] 0 [TOTAL] 25
```